### PR TITLE
Fix link

### DIFF
--- a/readme.org
+++ b/readme.org
@@ -12,7 +12,7 @@ Well, you have come to the right place.
 - [[https://arxiv.org/abs/1608.08225][Why does deep and cheap learning work so well?]] by Lin at al.
 - [[https://arxiv.org/abs/1811.03804][Gradient Descent Finds Global Minima of Deep Neural Networks]] by Du et al.
 ** Books
-- [[deeplearningbook.org][Deep Learning]] by Ian Goodfellow, Yoshua Bengio, Aaron Courville
+- [[http://deeplearningbook.org][Deep Learning]] by Ian Goodfellow, Yoshua Bengio, Aaron Courville
 - [[http://incompleteideas.net/book/ebook/the-book.html][Reinforcement Learning: An Introduction]] by Richard Sutton
 - [[http://cs.huji.ac.il/~shais/UnderstandingMachineLearning/][Understanding Machine Learning: From Theory to Algorithms]] by Shai Shalev-Shwartz and Shai Ben-David
 - [[https://www.math.uci.edu/%7Ervershyn/papers/HDP-book/HDP-book.pdf][High-Dimensional Probability]] by Roman Vershynin


### PR DESCRIPTION
As the link isn't preceded by `http://`, Github's Markdown parser interprets it as a relative link and sets it to `/dit7ya/awesome-mathy-machine-learning/blob/master/deeplearningbook.org`.
This PR fixes this.